### PR TITLE
use regex for vim checks

### DIFF
--- a/bin/tmux-vim-select-pane
+++ b/bin/tmux-vim-select-pane
@@ -5,7 +5,7 @@ set -e
 
 cmd="$(tmux display -p '#{pane_current_command}')"
 
-if [ "${cmd,,*}" = "vim" ]; then
+if [[ `echo ${cmd,,*} | xargs basename` =~ vim|vi ]]; then
   direction="$(echo "${1#-}" | tr 'lLDUR' '\\hjkl')"
   # forward the keystroke to Vim
   tmux send-keys "C-$direction"


### PR DESCRIPTION
Instead of testing whether a switch to vim has been made with equality, use regex. 

This fixes the issue when pane command is `/usr/bin/vim`, but still supports ordinary `vim`.
