### PR TITLE
Fix tmux-vim-select-pane.

### DIFF
--- a/bin/tmux-vim-select-pane
+++ b/bin/tmux-vim-select-pane
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Like `tmux select-pane`, but sends a `<C-h/j/k/l>` keystroke if Vim is
 # running in the current pane, or only one pane exists.
-set -e
 
 cmd="$(tmux display -p '#{pane_current_command}')"
 cmd="$(basename "$cmd" | tr A-Z a-z)"

--- a/bin/tmux-vim-select-pane
+++ b/bin/tmux-vim-select-pane
@@ -7,10 +7,26 @@ cmd="$(basename "$cmd" | tr A-Z a-z)"
 pane_count="$(printf %d $(tmux list-panes | wc -l))"
 
 echo "${cmd}" | grep -q 'vi'
-if [[ $? || ($pane_count = 1) ]]; then
-  direction="$(echo "${1#-}" | tr 'lLDUR' '\\hjkl')"
+if [[ ( $? || $pane_count == 1) ]]; then
+  case "$1" in
+    '-L')
+      vim_key='C-h'
+      ;;
+    '-D')
+      vim_key='C-j'
+      ;;
+    '-U')
+      vim_key='C-k'
+      ;;
+    '-R')
+      vim_key='C-l'
+      ;;
+    '-l')
+      vim_key='C-\'
+      ;;
+  esac
   # forward the keystroke to Vim
-  tmux send-keys "C-$direction"
+  tmux send-keys "$vim_key"
 else
   tmux select-pane "$@"
 fi

--- a/bin/tmux-vim-select-pane
+++ b/bin/tmux-vim-select-pane
@@ -7,7 +7,7 @@ cmd="$(basename "$cmd" | tr A-Z a-z)"
 pane_count="$(printf %d $(tmux list-panes | wc -l))"
 
 echo "${cmd}" | grep -q 'vi'
-if [[ ( $? || $pane_count == 1) ]]; then
+if [ $? == 0 ] || [ $pane_count == 1 ]; then
   case "$1" in
     '-L')
       vim_key='C-h'

--- a/bin/tmux-vim-select-pane
+++ b/bin/tmux-vim-select-pane
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Like `tmux select-pane`, but sends a `<C-h/j/k/l>` keystroke if Vim is
 # running in the current pane, or only one pane exists.
 set -e
@@ -7,10 +7,12 @@ cmd="$(tmux display -p '#{pane_current_command}')"
 cmd="$(basename "$cmd" | tr A-Z a-z)"
 pane_count="$(printf %d $(tmux list-panes | wc -l))"
 
-if [[ "${cmd%m}" = "vi" || ($pane_count = 1) ]]; then
+echo "${cmd}" | grep -q 'vi'
+if [[ $? || ($pane_count = 1) ]]; then
   direction="$(echo "${1#-}" | tr 'lLDUR' '\\hjkl')"
   # forward the keystroke to Vim
   tmux send-keys "C-$direction"
 else
   tmux select-pane "$@"
 fi
+


### PR DESCRIPTION
From some reason, recently the script stopped working for me so I've made these
changes. It is also supposed to be compatible with non GNU systems when the
interpreter is `/bin/sh`.